### PR TITLE
String spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - Allow logging a single value with `<Inspect.Value value={foo} />`, without formatting as a variable.
+- Print sequences of whitespace correctly in strings, object keys, regex source, element attribute values and Symbol keys

--- a/inspect/Property.svelte
+++ b/inspect/Property.svelte
@@ -20,11 +20,14 @@
   {...(getter ? {descriptor, context} : {value, depth: enumerable ? depth : 0})}
 >
   <span class=key class:enumerable class:index={keyIsIndex(key)}>
-    {String(key)}<span class=separator>{separator}</span>
+    <span class=pre>{String(key)}</span><span class=separator>{separator}</span>
   </span>
 </svelte:component>
 
 <style>
+  .pre {
+    white-space: pre-wrap;
+  }
   .key {
     color: var(--color-purple);
   }

--- a/inspect/formatters/ElementFormatter.svelte
+++ b/inspect/formatters/ElementFormatter.svelte
@@ -56,6 +56,7 @@
     color: var(--color-brown);
   }
   .attribute-value {
+    white-space: pre-wrap;
     color: var(--color-red);
   }
 </style>

--- a/inspect/formatters/RegExpFormatter.svelte
+++ b/inspect/formatters/RegExpFormatter.svelte
@@ -29,6 +29,7 @@
     color: var(--color-black);
   }
   .source {
+    white-space: pre-wrap;
     color: var(--color-red);
   }
   .flags {

--- a/inspect/formatters/StringFormatter.svelte
+++ b/inspect/formatters/StringFormatter.svelte
@@ -31,6 +31,7 @@
     color: var(--color-black);
   }
   .chars {
+    white-space: pre-wrap;
     color: var(--color-red);
   }
   .chars.escape {

--- a/inspect/formatters/SymbolFormatter.svelte
+++ b/inspect/formatters/SymbolFormatter.svelte
@@ -24,6 +24,7 @@
 
 <style>
   .key {
+    white-space: pre-wrap;
     color: var(--color-red);
   }
   .affix {


### PR DESCRIPTION
Adds `white-space: pre-wrap` to a number of places where sequences of whitespace can be expected.