### PR TITLE
Fix duplicate slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.3
+- Fix repeated slot names, which are no longer supported by Svelte.
+
 ## 0.1.2
 - Support configuration even in SSR mode.
 - Clean up MapEntry.svelte to avoid unused CSS warning.

--- a/inspect/Echo.svelte
+++ b/inspect/Echo.svelte
@@ -1,2 +1,2 @@
 <!-- Helper to avoid whitespace between inline elements -->
-<slot /><slot name=slot />
+<slot name=1 /><slot name=2 /><slot name=3 /><slot name=4 />

--- a/inspect/formatters/ArrayFormatter.svelte
+++ b/inspect/formatters/ArrayFormatter.svelte
@@ -17,9 +17,9 @@
 <Toggle className=array-toggle bind:isOpen>
   <slot />
   <Echo>
-    <span slot=slot class=array>Array(</span>
-    <span slot=slot class=length>{value.length}</span>
-    <span slot=slot class=array>)</span>
+    <span slot=1 class=array>Array(</span>
+    <span slot=2 class=length>{value.length}</span>
+    <span slot=3 class=array>)</span>
   </Echo>
   [{#if !isOpen}
     <span class=on-intent>…</span>]

--- a/inspect/formatters/DateFormatter.svelte
+++ b/inspect/formatters/DateFormatter.svelte
@@ -21,18 +21,18 @@
 <PrimitiveBase {value}>
   <slot />
   <Echo>
-    <span slot=slot>Date(</span>
-    <span slot=slot class=date>
+    <span slot=1>Date(</span>
+    <span slot=2 class=date>
       {#each grouper(date) as {key, match}}
         <span class={key || 'default'}>{match}</span>
       {/each}
     </span>
-    <span slot=slot class=time>
+    <span slot=3 class=time>
       {#each grouper(time) as {key, match}}
         <span class={key || 'default'}>{match}</span>
       {/each}
     </span>
-    <span slot=slot>)</span>
+    <span slot=4>)</span>
   </Echo>
 </PrimitiveBase>
 

--- a/inspect/formatters/ElementFormatter.svelte
+++ b/inspect/formatters/ElementFormatter.svelte
@@ -22,26 +22,26 @@
 <PrimitiveBase {value}>
   <slot />
   <Echo>
-    <span slot=slot class=punctuation>&lt;</span>
-    <span slot=slot class=tag-name>{value.tagName.toLowerCase()}</span>
-    <span slot=slot>
+    <span slot=1 class=punctuation>&lt;</span>
+    <span slot=2 class=tag-name>{value.tagName.toLowerCase()}</span>
+    <span slot=3>
       {#each value.attributes as attribute}
         {' '}
         {#if attribute.value}
           <Echo>
-            <span slot=slot class=attribute-name>{attribute.name}</span>
-            <span slot=slot class=punctuation>="</span>
-            <span slot=slot class=attribute-value>{attribute.value}</span>
-            <span slot=slot class=punctuation>"</span>
+            <span slot=1 class=attribute-name>{attribute.name}</span>
+            <span slot=2 class=punctuation>="</span>
+            <span slot=3 class=attribute-value>{attribute.value}</span>
+            <span slot=4 class=punctuation>"</span>
           </Echo>
         {:else}
           <Echo>
-            <span slot=slot class=attribute-name>{attribute.name}</span>
+            <span slot=1 class=attribute-name>{attribute.name}</span>
           </Echo>
         {/if}
       {/each}
     </span>
-    <span slot=slot class=punctuation>&gt;</span>
+    <span slot=4 class=punctuation>&gt;</span>
   </Echo>
 </PrimitiveBase>
 

--- a/inspect/formatters/MapFormatter.svelte
+++ b/inspect/formatters/MapFormatter.svelte
@@ -20,9 +20,9 @@
 <Toggle className=map-toggle bind:isOpen>
   <slot />
   <Echo>
-    <span slot=slot class=map>Map(</span>
-    <span slot=slot class=size>{value.size}</span>
-    <span slot=slot class=map>)</span>
+    <span slot=1 class=map>Map(</span>
+    <span slot=2 class=size>{value.size}</span>
+    <span slot=3 class=map>)</span>
   </Echo>
   &lcub;{#if !isOpen}
     <span class=on-intent>…</span>&rcub;

--- a/inspect/formatters/RegExpFormatter.svelte
+++ b/inspect/formatters/RegExpFormatter.svelte
@@ -16,10 +16,10 @@
   <slot />
   <span class=regexp>
     <Echo>
-      <span slot=slot class=slash>/</span>
-      <span slot=slot class=source>{source}</span>
-      <span slot=slot class=slash>/</span>
-      <span slot=slot class=flags>{flags}</span>
+      <span slot=1 class=slash>/</span>
+      <span slot=2 class=source>{source}</span>
+      <span slot=3 class=slash>/</span>
+      <span slot=4 class=flags>{flags}</span>
     </Echo>
   </span>
 </PrimitiveBase>

--- a/inspect/formatters/SetFormatter.svelte
+++ b/inspect/formatters/SetFormatter.svelte
@@ -20,9 +20,9 @@
 <Toggle className=set-toggle bind:isOpen>
   <slot />
   <Echo>
-    <span slot=slot class=set>Set(</span>
-    <span slot=slot class=size>{value.size}</span>
-    <span slot=slot class=set>)</span>
+    <span slot=1 class=set>Set(</span>
+    <span slot=2 class=size>{value.size}</span>
+    <span slot=3 class=set>)</span>
   </Echo>
   &lcub;{#if !isOpen}
     <span class=on-intent>…</span>&rcub;

--- a/inspect/formatters/SymbolFormatter.svelte
+++ b/inspect/formatters/SymbolFormatter.svelte
@@ -16,9 +16,9 @@
 <PrimitiveBase {value}>
   <slot />
   <Echo>
-    <span slot=slot class=affix>{prefix}</span>
-    <span slot=slot class=key>{key}</span>
-    <span slot=slot class=affix>)</span>
+    <span slot=1 class=affix>{prefix}</span>
+    <span slot=2 class=key>{key}</span>
+    <span slot=3 class=affix>)</span>
   </Echo>
 </PrimitiveBase>
 

--- a/inspect/formatters/TypedArrayFormatter.svelte
+++ b/inspect/formatters/TypedArrayFormatter.svelte
@@ -38,9 +38,9 @@
 <Toggle className=typed-array-toggle bind:isOpen>
   <slot />
   <Echo>
-    <span slot=slot class=typed-array>{typeDescription}(</span>
-    <span slot=slot class=length>{value.length}</span>
-    <span slot=slot class=typed-array>)</span>
+    <span slot=1 class=typed-array>{typeDescription}(</span>
+    <span slot=2 class=length>{value.length}</span>
+    <span slot=3 class=typed-array>)</span>
   </Echo>
   [{#if !isOpen}
     <span class=on-intent>…</span>]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-inspect",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Svelte object inspector",
   "svelte": "svelte-inspect.js",
   "repository": "github:trbrc/svelte-inspect",


### PR DESCRIPTION
Change the `<Echo>` to list a number of explicit slots, as duplicate slot names are not supported in Svelte anymore.

Closes #7 